### PR TITLE
Indentation fixes

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -19,9 +19,12 @@ class User
     public const EDIT_PROFILE_ACTION = 'EditProfile';
     public const DELETE_ACCOUNT_ACTION = 'DeleteAccount';
     public const DATA_TAKEOUT = 'TakeOut';
+
     private const DATETIME_FORMAT = 'Y-m-d H:i:s';
     private const CSV_TAKEOUT_HEADER = 'user id,email,name,profile created date,profile modified date,terms acceptance date';
     private const FORGOT_PASSWORD_LENGTH = 10;
+
+    /** @var PDO */
     protected $connection;
 
     public function __construct(PDO $con)


### PR DESCRIPTION
Add blank newline between private and public constants and add phpDoc on class property. Later, once the project supports PHP 7.4, it will be replaced by the PHP typed property `protected PDO $connection` instead of the phpDoc comment.